### PR TITLE
Issue 45 フォルダを作成する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ export const App = () => {
 
   // 初回useEffectでaccessTokenをサーバー側で認証する
   // アクセストークンがあればOKとする。AuthContextでlocalStorageに保管する
-  /*
+  
   if (!user.accessToken) {
     return <Signin />
   } else {
@@ -29,23 +29,7 @@ export const App = () => {
         </div>
       </NoteContainer>
     );  
-  } 
-  */  
-  return (
-    <NoteContainer>
-      <NavigationContainer>
-        <div className="logo">
-          Cloud Note App
-        </div>
-        <nav id="nav">        
-          <NoteList />
-        </nav>
-      </NavigationContainer>        
-      <div className="editor-container">
-        <Note />
-      </div>
-    </NoteContainer>
-  );  
+  }       
 }
 
 const NoteContainer = styled.div`

--- a/frontend/src/NoteList/CreateFolderButton.jsx
+++ b/frontend/src/NoteList/CreateFolderButton.jsx
@@ -6,28 +6,32 @@ import { AuthContext } from "../Providers/AuthProvider";
 
 export const CreateFolderButton = () => {
 
-  const { setNote, notesList, setNotesList } = useContext(ShowNoteContext);
+  const { folders, setFolders } = useContext(ShowNoteContext);
   const { user } = useContext(AuthContext);
   /**
    * FolderIcon onClick
    */
   const onClickCreateFolder = async () => {
     // UserID    
-    //const userId = user["id"];
+    const userId = user["id"];
     // 認証が現在通らないので、あらかじめ作ったダミーデータを利用する
-    const userId = "8a940d80-2d62-4e59-885e-5b67df590f8a";
+    //const userId = "8a940d80-2d62-4e59-885e-5b67df590f8a";
     // Post
-    const resData = await axios.post('/folders', {userId: userId});
+    const resData = await axios.post('/folders', {userId: userId, name: "新規フォルダ"});
     // FolderId
     const folderId = resData.data['id'];
     // State 更新
-    await createFolder(folderId)
+    await createFolder(folderId);
   };
   /**
    * State 更新処理
    */
-  const createFolder = async (folderId) => {
-
+  const createFolder = async (folderId) => {   
+    // 配列に追加
+    folders.push({folderId: folderId, folderName: "新規フォルダ"});
+    // 再描画用に新規配列
+    const newFolders = folders.slice();
+    setFolders(newFolders);    
   };
 
   return (

--- a/frontend/src/NoteList/CreateNoteButton.jsx
+++ b/frontend/src/NoteList/CreateNoteButton.jsx
@@ -13,9 +13,9 @@ export const CreateNoteButton = () => {
    */
   const onClickCreate = async () => {
     // UserID    
-    //const userId = user["id"];
+    const userId = user["id"];
     // 認証が現在通らないので、あらかじめ作ったダミーデータを利用する
-    const userId = "8a940d80-2d62-4e59-885e-5b67df590f8a";
+    //const userId = "8a940d80-2d62-4e59-885e-5b67df590f8a";
     // ユーザーIDを渡して、新規ノート作成
     const resData = await axios.post(`/notes`, {userId: userId});
     // ノートIDを取得

--- a/frontend/src/NoteList/NoteList.jsx
+++ b/frontend/src/NoteList/NoteList.jsx
@@ -11,7 +11,7 @@ import { ShowNoteContext } from "../Providers/ShowNoteProvider";
  */
 export const NoteList = () => {  
   
-  const { notesList, setNotesList } = useContext(ShowNoteContext);    
+  const { notesList, setNotesList, folders, setFolders } = useContext(ShowNoteContext);    
   const [ notes, setNotes ] = useState();    
   // 再描画の制御  
   useEffect(() => {
@@ -24,20 +24,26 @@ export const NoteList = () => {
       // フォルダなし    
       notesData["notesWithoutFolder"].forEach(({ id, title, content }) => {            
         // 配列のインデックスを取得
-        const index = notesList.findIndex(({noteId}) => noteId === id);
+        const noteIndex = notesList.findIndex(({noteId}) => noteId === id);
         // ノート新規作成時に重複しないようにチェック
-        if (index === -1) {
+        if (noteIndex === -1) {
           // 配列に追加
           notesList.push({ noteId: id, title, body: content });      
         }        
       });
       // フォルダあり
-      notesData["folders"].forEach(({notes}) => {      
+      notesData["folders"].forEach(({id, name, notes}) => {     
+        // 重複チェック
+        const folderIndex = folders.findIndex(({folderId}) => folderId === id);
+
+        if (folderIndex === -1) {
+          folders.push({ folderId: id,folderName: name });
+        }        
         notes.forEach(({ id, title, content }) => {        
           // 配列のインデックスを取得
-          const index = notesList.findIndex(({noteId}) => noteId === id);
+          const noteIndex = notesList.findIndex(({noteId}) => noteId === id);
           // ノート新規作成時に重複しないようにチェック
-          if (index === -1) {
+          if (noteIndex === -1) {
             // 配列に追加
             notesList.push({ noteId: id, title, body: content });      
           }                  
@@ -47,10 +53,14 @@ export const NoteList = () => {
       if (notesList[0]["noteId"] === "") {
         notesList.shift();
       }      
+      if (folders[0]["folderId"] === "") {
+        folders.shift();
+      }
       // State更新
-      setNotesList(notesList);                   
+      setNotesList(notesList);    
+      setFolders(folders);      
     })();
-  }, [notesList, setNotesList]);         
+  }, [notesList, setNotesList, folders, setFolders]);         
   /**
    * list-style: none;
    */

--- a/frontend/src/Providers/ShowNoteProvider.jsx
+++ b/frontend/src/Providers/ShowNoteProvider.jsx
@@ -21,9 +21,18 @@ export const ShowNoteProvider = props => {
       }
     ]    
   );
+  // フォルダ情報
+  const [ folders, setFolders ] = useState(
+    [
+      {
+        folderId: "",
+        folderName: "",
+      }
+    ]
+  );
 
   return (
-    <ShowNoteContext.Provider value={{ notesList, setNotesList, note, setNote }}>
+    <ShowNoteContext.Provider value={{ notesList, setNotesList, note, setNote, folders, setFolders }}>
       {children}
     </ShowNoteContext.Provider>
   );


### PR DESCRIPTION
### 実装概要
・フォルダ作成アイコンをノート作成ボタンの隣に配置
・アイコンクリックでフォルダを新規作成する

### 実装内容

- `NoteList`に`CreateFolderButton`コンポーネントを追加
- `useContext`に、フォルダ用に `folders`, `setFolders`を追加
- フォルダの作成時にも`State`を更新するために、`useEffect`内にフォルダ用Stateを記述。
- アイコンクリック時にAPIを呼び出し、「新規フォルダ」というタイトルでフォルダを作成

### 懸案

フォルダ用のStateについて、`useContext`に入れるべきかどうか迷った。